### PR TITLE
Citeme!

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,11 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- family-names: "Grigson"
+  given-names: "Susanna"
+  orcid: "0000-0003-4738-3451"
+title: "Phynteny: Synteny-based annotation of bacteriophage genes"
+version: 0.1.13
+doi: 10.5281/zenodo.8128898
+date-released: 2024-04-22
+url: "https://github.com/susiegriggo/Phynteny"


### PR DESCRIPTION
This PR adds a [citation file](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files) so that we can cite phynteny. It currently uses the zenodo DOI, but we can ultimately replace that with the reference.